### PR TITLE
:sparkles:  Feat: Profile 컴포넌트 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,7 @@
-import Test from '@components/Test/Test';
 import '@styles/index.scss';
 
 function App() {
-  return <Test />;
+  return <></>;
 }
 
 export default App;

--- a/src/components/Test/Style.scss
+++ b/src/components/Test/Style.scss
@@ -1,3 +1,0 @@
-button.small {
-	background-color: red;
-}

--- a/src/components/Test/Test.tsx
+++ b/src/components/Test/Test.tsx
@@ -1,5 +1,0 @@
-import './Style.scss';
-
-const Test = () => <button className="small">하이</button>;
-
-export default Test;

--- a/src/components/base/Profile/Profile.tsx
+++ b/src/components/base/Profile/Profile.tsx
@@ -1,0 +1,28 @@
+import gravatar from 'gravatar';
+import { PROFILE_SIZE } from '@styles/constants/size';
+import './Style.scss';
+
+interface ProfileProps {
+  userId: string;
+  profileImage?: string;
+}
+
+// @NOTE: profile url: https://unsplash.it/100
+
+const Profile = ({ userId, profileImage }: ProfileProps) => {
+  return (
+    <div className="profileWrapper">
+      <img
+        className="profile"
+        src={
+          profileImage
+            ? profileImage
+            : gravatar.url(userId, { s: PROFILE_SIZE, d: 'retro' })
+        }
+        alt="프로필 이미지"
+      />
+    </div>
+  );
+};
+
+export default Profile;

--- a/src/components/base/Profile/Style.scss
+++ b/src/components/base/Profile/Style.scss
@@ -1,0 +1,12 @@
+.profileWrapper {
+	display: inline-block;
+	width: $PROFILE_SIZE;
+	height: $PROFILE_SIZE;
+	
+	.profile {
+		width: 100%;
+		height: 100%;
+		object-fit: scale-down;
+		border-radius: 50%;
+	}
+}

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -1,0 +1,1 @@
+export { default as Profile } from './Profile/Profile';

--- a/src/styles/constants/_sizes.scss
+++ b/src/styles/constants/_sizes.scss
@@ -1,0 +1,1 @@
+$PROFILE_SIZE: 40px;

--- a/src/styles/constants/size.ts
+++ b/src/styles/constants/size.ts
@@ -1,0 +1,3 @@
+// @NOTE: scss와 jsx가 분리되어 있어 scss 변수를 가져올 수 없음. jsx에 쓸 변수 따로 선언
+
+export const PROFILE_SIZE = '40px';


### PR DESCRIPTION
- Closes #3

- profileImage prop이 없다면 gravatar 생성, 있다면 profileImage로 보임

- userId에 따라 gravatar 해쉬 생성
![image](https://user-images.githubusercontent.com/68528752/153379830-85396a50-9954-4e14-abca-9ac0c7fb1285.png)

- profileImage는 `https://unsplash.it/100` 로 하는 게 좋을 듯